### PR TITLE
Fix mailing service

### DIFF
--- a/backend/apps/mailings/services/base/email_sender.py
+++ b/backend/apps/mailings/services/base/email_sender.py
@@ -64,7 +64,15 @@ class EmailSender:
 
     @log_errors()
     def _load_config(self):
-        with open("./Main.config", 'r', encoding='utf-8-sig') as json_file:
+        """Load JSON configuration used by the mailing helpers.
+
+        In the open-source version the configuration file is optional. When it
+        is missing we return an empty dictionary so that the sender can be
+        configured programmatically."""
+        config_path = os.path.join(settings.BASE_DIR, "Main.config")
+        if not os.path.exists(config_path):
+            return {}
+        with open(config_path, 'r', encoding='utf-8-sig') as json_file:
             return json.load(json_file)
 
     def _structure_updates_3x(self, updates):

--- a/backend/apps/mailings/services/runners/send_mailing.py
+++ b/backend/apps/mailings/services/runners/send_mailing.py
@@ -1,1 +1,22 @@
+"""Helpers to send production mailings using :class:`EmailSender`."""
+
 from apps.mailings.services.base.email_sender import EmailSender
+
+
+def send_mailing(emails, release_type, server_version='', ipad_version='', android_version='', language='ru'):
+    """Send a mailing to the provided list of emails.
+
+    Parameters mirror the ones used by :class:`EmailSender`. The function
+    instantiates the sender and calls ``send_email``. ``emails`` can be a single
+    address or an iterable of addresses."""
+
+    sender = EmailSender(
+        emails=emails,
+        mailing_type="standard_mailing",
+        release_type=release_type,
+        server_version=server_version,
+        ipad_version=ipad_version,
+        android_version=android_version,
+        language=language,
+    )
+    return sender.send_email()

--- a/backend/apps/mailings/services/runners/send_test_email.py
+++ b/backend/apps/mailings/services/runners/send_test_email.py
@@ -1,1 +1,17 @@
+"""Helpers to send a test mailing using :class:`EmailSender`."""
+
 from apps.mailings.services.base.email_sender import EmailSender
+
+
+def send_test_email(email, release_type, server_version='', ipad_version='', android_version='', language='ru'):
+    """Send a single test email."""
+    sender = EmailSender(
+        emails=[email],
+        mailing_type="standard_mailing",
+        release_type=release_type,
+        server_version=server_version,
+        ipad_version=ipad_version,
+        android_version=android_version,
+        language=language,
+    )
+    return sender.send_email()

--- a/backend/apps/mailings/services/utils/attachments.py
+++ b/backend/apps/mailings/services/utils/attachments.py
@@ -1,1 +1,35 @@
 import os
+from email.mime.base import MIMEBase
+from email.mime.image import MIMEImage
+from email import encoders
+
+"""Utility stubs for mailing attachments.
+These functions are simplified versions of the original utilities
+used in the proprietary project. They perform no-op operations so that
+mail sending logic can work in this open source example."""
+
+def attach_images(msg, logger=None):
+    """Attach images to the message if any exist.
+    In this stripped down version the function does nothing."""
+    if logger:
+        logger.debug("attach_images called but no images are configured")
+
+
+def attach_files(msg, language, logger=None):
+    """Attach additional files to the message.
+    This is a stub implementation that simply logs the action."""
+    if logger:
+        logger.debug("attach_files called for language %s", language)
+
+
+def update_documentation(language, release_type, server_version, ipad_version, android_version, config):
+    """Prepare documentation before sending emails.
+    No-op for the simplified open source version."""
+    pass
+
+
+def embed_hidden_logo(html, language):
+    """Return HTML with an embedded logo.
+    The real implementation embeds an inline image. Here we just return the HTML
+    unchanged so that templates can be rendered without additional assets."""
+    return html

--- a/backend/apps/mailings/services/utils/retry_and_logging.py
+++ b/backend/apps/mailings/services/utils/retry_and_logging.py
@@ -1,1 +1,26 @@
-import os
+import logging
+from functools import wraps
+
+"""Utility decorator used in the mailing service.
+In the original project it performed automatic retries and logging.
+This simplified version only logs exceptions and re-raises them."""
+
+def log_errors(logger=None, extra_info=None):
+    """Decorator for logging exceptions inside mailing helpers."""
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except Exception as exc:  # pragma: no cover - simple logging wrapper
+                log = logger or logging.getLogger(func.__module__)
+                message = str(exc)
+                if callable(extra_info):
+                    try:
+                        message = extra_info(*args, **kwargs, error=exc)
+                    except Exception:  # safety
+                        pass
+                log.error(message)
+                raise
+        return wrapper
+    return decorator


### PR DESCRIPTION
## Summary
- add stub utilities for mailing attachments
- implement logging helper for mailing services
- allow EmailSender to run without external config
- provide helper runners for sending mail
- integrate EmailSender into the mailing task

## Testing
- `pip install -q -r backend/requirements.txt`
- `python backend/manage.py test apps.mailings.tests.BasicTestCase -v 2` *(fails: CSRF_TRUSTED_ORIGINS not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845136c359c8332abeb07b4d5cf7c63