### PR TITLE
Fix mailing service

### DIFF
--- a/backend/apps/mailings/services/clients/get_clients.py
+++ b/backend/apps/mailings/services/clients/get_clients.py
@@ -1,5 +1,7 @@
 from apps.clients.models import Client, Contact, TechnicalInfo
-from logger.log_config import scripts_info_logger, scripts_error_logger
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def get_clients_for_mailing(version_prefix):
@@ -31,9 +33,9 @@ def get_clients_for_mailing(version_prefix):
             if emails:
                 clients_for_mailing[client_id] = list(emails)
 
-        scripts_info_logger.info(f"Найдено {len(clients_for_mailing)} клиентов для рассылки.")
+        logger.info("Найдено %s клиентов для рассылки.", len(clients_for_mailing))
         return clients_for_mailing
 
     except Exception as e:
-        scripts_error_logger.error(f"Ошибка при получении клиентов для рассылки: {e}")
+        logger.error("Ошибка при получении клиентов для рассылки: %s", e)
         return {}

--- a/backend/apps/mailings/services/clients/save_release_info.py
+++ b/backend/apps/mailings/services/clients/save_release_info.py
@@ -1,5 +1,7 @@
 from apps.clients.models import Client
-from logger.log_config import scripts_info_logger, scripts_error_logger
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def save_release_info(client_id, release_number, release_type, component_type, emails):
@@ -15,8 +17,13 @@ def save_release_info(client_id, release_number, release_type, component_type, e
     """
     try:
         client = Client.objects.get(pk=client_id)
-        scripts_info_logger.info(
-            f"Рассылка {release_number} ({release_type}/{component_type}) отправлена клиенту {client.client_name}: {emails}"
+        logger.info(
+            "Рассылка %s (%s/%s) отправлена клиенту %s: %s",
+            release_number,
+            release_type,
+            component_type,
+            client.client_name,
+            emails,
         )
     except Exception as e:
-        scripts_error_logger.error(f"Ошибка логирования рассылки: {e}")
+        logger.error("Ошибка логирования рассылки: %s", e)

--- a/backend/apps/mailings/services/integrations/confluence.py
+++ b/backend/apps/mailings/services/integrations/confluence.py
@@ -3,10 +3,8 @@ from bs4 import BeautifulSoup
 import json
 import os
 import logging
-from logger.log_config import setup_logger, get_abs_log_path
 
-scripts_error_logger = setup_logger('scripts_error', get_abs_log_path('scripts_errors.log'), logging.ERROR)
-scripts_info_logger = setup_logger('scripts_info', get_abs_log_path('scripts_info.log'), logging.INFO)
+logger = logging.getLogger(__name__)
 
 logging.getLogger("atlassian").setLevel(logging.WARNING)
 logging.getLogger("rest_client").setLevel(logging.WARNING)
@@ -22,7 +20,7 @@ def get_server_release_notes(server_version, lang_key):
     try:
         confluence = Confluence(url=url, username=USERNAME, password=PASSWORD)
     except Exception as error_message:
-        scripts_error_logger.error(f"Не удалось создать объект Confluence: {error_message}")
+        logger.error("Не удалось создать объект Confluence: %s", error_message)
         raise
     server_title = f"BM {server_version}"
     try:
@@ -31,14 +29,14 @@ def get_server_release_notes(server_version, lang_key):
             server_updates = extract_content(page)
             return server_updates.get(lang_key, [])
     except Exception as error_message:
-        scripts_error_logger.error(f"Не удалось получить страницы: {error_message}")
+        logger.error("Не удалось получить страницы: %s", error_message)
         raise
     return []
 
 
 def get_ipad_release_notes(ipad_version, lang_key):
     if not ipad_version:
-        scripts_info_logger.info("Мобильная версия iPad не указана.")
+        logger.info("Мобильная версия iPad не указана.")
         return []
     with open("Main.config", 'r', encoding='utf-8-sig') as file:
         data = json.load(file)
@@ -48,24 +46,24 @@ def get_ipad_release_notes(ipad_version, lang_key):
     try:
         confluence = Confluence(url=url, username=USERNAME, password=PASSWORD)
     except Exception as error_message:
-        scripts_error_logger.error(f"Не удалось создать объект Confluence: {error_message}")
+        logger.error("Не удалось создать объект Confluence: %s", error_message)
         raise
     ipad_title = f"BM iOS/iPadOS {ipad_version}"
     try:
         page = confluence.get_page_by_title(title=ipad_title, space="development", expand='body.view')
         if not page or ('results' in page and not page['results']):
-            scripts_error_logger.error(f"Страница {ipad_title} не найдена.")
+            logger.error("Страница %s не найдена.", ipad_title)
             return []
         ipad_updates = extract_content(page)
         return ipad_updates.get(lang_key, [])
     except Exception as error_message:
-        scripts_error_logger.error(f"Не удалось получить страницы: {error_message}")
+        logger.error("Не удалось получить страницы: %s", error_message)
         raise
 
 
 def get_android_release_notes(android_version, lang_key):
     if not android_version:
-        scripts_info_logger.info("Мобильная версия Android не указана.")
+        logger.info("Мобильная версия Android не указана.")
         return []
     with open("Main.config", 'r', encoding='utf-8-sig') as file:
         data = json.load(file)
@@ -75,7 +73,7 @@ def get_android_release_notes(android_version, lang_key):
     try:
         confluence = Confluence(url=url, username=USERNAME, password=PASSWORD)
     except Exception as error_message:
-        scripts_error_logger.error(f"Не удалось создать объект Confluence: {error_message}")
+        logger.error("Не удалось создать объект Confluence: %s", error_message)
         raise
     android_title = f"Android {android_version}"
     try:
@@ -84,10 +82,10 @@ def get_android_release_notes(android_version, lang_key):
             android_updates = extract_content(page)
             return android_updates.get(lang_key, [])
         else:
-            scripts_error_logger.error(f"Страница {android_title} не найдена.")
+            logger.error("Страница %s не найдена.", android_title)
             return []
     except Exception as error_message:
-        scripts_error_logger.error(f"Не удалось получить страницы: {error_message}")
+        logger.error("Не удалось получить страницы: %s", error_message)
         raise
 
 
@@ -125,9 +123,9 @@ def extract_tables(tables):
                     if text:
                         updates[current_language].append(text)
     if not updates['Русский']:
-        scripts_info_logger.warning("Текст на русском языке отсутствует.")
+        logger.warning("Текст на русском языке отсутствует.")
     if not updates['Английский']:
-        scripts_info_logger.warning("Текст на английском языке отсутствует.")
+        logger.warning("Текст на английском языке отсутствует.")
     return updates
 
 
@@ -142,7 +140,7 @@ def extract_list(page_content):
             f"Найденные заголовки на странице: {all_headers}"
         )
         save_debug_html(soup)
-        scripts_error_logger.error(error_message)
+        logger.error(error_message)
         raise Exception(error_message)
     list_element = header.find_next_sibling(['ol', 'ul'])
     if not list_element:
@@ -151,7 +149,7 @@ def extract_list(page_content):
             "Убедитесь, что структура статьи корректна."
         )
         save_debug_html(soup)
-        scripts_error_logger.error(error_message)
+        logger.error(error_message)
         raise Exception(error_message)
     updates = []
     for item in list_element.find_all('li'):
@@ -169,6 +167,6 @@ def save_debug_html(soup):
     try:
         with open(debug_file_path, 'w', encoding='utf-8') as debug_file:
             debug_file.write(soup.prettify())
-        scripts_info_logger.info(f"HTML страницы сохранен в {debug_file_path} для отладки.")
+        logger.info("HTML страницы сохранен в %s для отладки.", debug_file_path)
     except Exception as e:
-        scripts_error_logger.error(f"Не удалось сохранить HTML для отладки: {e}")
+        logger.error("Не удалось сохранить HTML для отладки: %s", e)

--- a/backend/apps/mailings/services/integrations/nextcloud.py
+++ b/backend/apps/mailings/services/integrations/nextcloud.py
@@ -1,10 +1,8 @@
 import requests
 from urllib.parse import quote
 import logging
-from logger.log_config import setup_logger, get_abs_log_path
 
-scripts_error_logger = setup_logger('scripts_error', get_abs_log_path('scripts_errors.log'), logging.ERROR)
-scripts_info_logger = setup_logger('scripts_info', get_abs_log_path('scripts_info.log'), logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 class NextcloudManager:
@@ -26,7 +24,7 @@ class NextcloudManager:
         with open(local_path, 'rb') as f:
             resp = requests.put(url, data=f, auth=(self.username, self.password), timeout=self.timeout)
         if resp.status_code not in (200, 201, 204):
-            scripts_error_logger.error("Ошибка загрузки %s: %s", remote_path, resp.text)
+            logger.error("Ошибка загрузки %s: %s", remote_path, resp.text)
 
     def folder_exists(self, path):
         url = self._build_url(path)

--- a/backend/apps/mailings/services/integrations/skin_move.py
+++ b/backend/apps/mailings/services/integrations/skin_move.py
@@ -10,10 +10,9 @@ from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_excep
 from apps.clients.models import Client, TechnicalInfo
 from .nextcloud import NextcloudManager
 from .yandex_disk import upload_to_nextcloud
-from logger.log_config import setup_logger, get_abs_log_path
+import logging
 
-scripts_error_logger = setup_logger('scripts_error', get_abs_log_path('scripts_errors.log'))
-scripts_info_logger = setup_logger('scripts_info', get_abs_log_path('scripts_info.log'))
+logger = logging.getLogger(__name__)
 
 CONFIG_FILE = "Main.config"
 with open(CONFIG_FILE, 'r', encoding='utf-8-sig') as file:
@@ -50,12 +49,12 @@ def download_files(release_path, skin_filename):
     )
     result = subprocess.run(smbclient_command, shell=True, cwd=temp_dir, capture_output=True, text=True)
     if "NT_STATUS_OBJECT_NAME_NOT_FOUND" in result.stdout:
-        scripts_info_logger.warning(f'Файл {skin_filename} отсутствует в {release_path}, клиент пропущен.')
+        logger.warning('Файл %s отсутствует в %s, клиент пропущен.', skin_filename, release_path)
         return "NO_FILE"
     if result.returncode != 0:
-        scripts_error_logger.error(f'Ошибка скачивания {skin_filename}: {result.stderr.strip() or "Неизвестная ошибка"}')
+        logger.error('Ошибка скачивания %s: %s', skin_filename, result.stderr.strip() or 'Неизвестная ошибка')
         return "ERROR"
-    scripts_info_logger.info(f'Файл {skin_filename} успешно скачан в {temp_dir}')
+    logger.info('Файл %s успешно скачан в %s', skin_filename, temp_dir)
     return temp_dir
 
 
@@ -72,12 +71,12 @@ def move_old_boardmaps_folder(client_name, folder_type, version):
                 old_boardmaps_path = f"{client_directory}{folder}"
                 destination_path = f"{old_versions_path}{folder}"
                 nextcloud_module.move_folder(old_boardmaps_path, destination_path)
-                scripts_info_logger.info(f'Перемещена старая папка "{folder}" в "{old_versions_path}"')
+                logger.info('Перемещена старая папка "%s" в "%s"', folder, old_versions_path)
                 return None
-        scripts_info_logger.info(f'Нет старых папок "BoardMaps {folder_type} ..." для перемещения.')
+        logger.info('Нет старых папок "BoardMaps %s ..." для перемещения.', folder_type)
     except Exception as error:
         error_msg = f'Ошибка при перемещении старой папки "BoardMaps {folder_type} {version}": {error}'
-        scripts_error_logger.error(error_msg)
+        logger.error(error_msg)
         return error_msg
 
 
@@ -87,17 +86,17 @@ def move_skins_and_manage_share(version, component_type):
     folder_type = "iPad" if component_type == "ipad" else "Server"
     try:
         clients_list = get_clients_list(version, component_type)
-        scripts_info_logger.info(f'Найдено клиентов с {component_type}-скинами (версия {version}): {len(clients_list)}')
+        logger.info('Найдено клиентов с %s-скинами (версия %s): %s', component_type, version, len(clients_list))
         if not clients_list:
-            scripts_error_logger.error(f'Нет клиентов с {component_type}-скинами для версии {version}!')
+            logger.error('Нет клиентов с %s-скинами для версии %s!', component_type, version)
             return "NO_CLIENTS"
         for client in clients_list:
             short_name = client.get("short_name")
             full_name = client.get("client_name")
             if not short_name or not full_name:
-                scripts_info_logger.warning(f'Пропускаем клиента без имени: {client}')
+                logger.warning('Пропускаем клиента без имени: %s', client)
                 continue
-            scripts_info_logger.info(f'Обрабатываем клиента: "{full_name}" ({folder_type})')
+            logger.info('Обрабатываем клиента: "%s" (%s)', full_name, folder_type)
             try:
                 release_path = f"Releases/[{folder_type}-skins]/{version}"
                 skin_filename = f"{short_name}.zip" if component_type == "ipad" else f"{short_name}_theme.{version}.json.zip"
@@ -116,15 +115,15 @@ def move_skins_and_manage_share(version, component_type):
                     upload_to_nextcloud(local_skin_path, remote_skin_path, NEXTCLOUD_URL, NEXTCLOUD_USERNAME, NEXTCLOUD_PASSWORD)
                     os.remove(local_skin_path)
                 except Exception as e:
-                    scripts_error_logger.error(f'Ошибка загрузки {skin_filename} на NextCloud, клиент {full_name} пропущен: {e}')
+                    logger.error('Ошибка загрузки %s на NextCloud, клиент %s пропущен: %s', skin_filename, full_name, e)
                     continue
             except Exception as error_message:
                 error_msg = f'Ошибка обработки клиента "{full_name}": {error_message}'
-                scripts_error_logger.error(error_msg)
+                logger.error(error_msg)
                 return error_msg
-        scripts_info_logger.info(f'Перемещение {folder_type}-скинов успешно завершено')
+        logger.info('Перемещение %s-скинов успешно завершено', folder_type)
         return None
     except Exception as error_message:
         error_msg = f'Произошла ошибка при перемещении {folder_type}-скинов: {error_message}'
-        scripts_error_logger.error(error_msg)
+        logger.error(error_msg)
         return error_msg

--- a/backend/apps/mailings/services/runners/send_mailing.py
+++ b/backend/apps/mailings/services/runners/send_mailing.py
@@ -1,1 +1,22 @@
+"""Helpers to send production mailings using :class:`EmailSender`."""
+
 from apps.mailings.services.base.email_sender import EmailSender
+
+
+def send_mailing(emails, release_type, server_version='', ipad_version='', android_version='', language='ru'):
+    """Send a mailing to the provided list of emails.
+
+    Parameters mirror the ones used by :class:`EmailSender`. The function
+    instantiates the sender and calls ``send_email``. ``emails`` can be a single
+    address or an iterable of addresses."""
+
+    sender = EmailSender(
+        emails=emails,
+        mailing_type="standard_mailing",
+        release_type=release_type,
+        server_version=server_version,
+        ipad_version=ipad_version,
+        android_version=android_version,
+        language=language,
+    )
+    return sender.send_email()

--- a/backend/apps/mailings/services/runners/send_test_email.py
+++ b/backend/apps/mailings/services/runners/send_test_email.py
@@ -1,1 +1,17 @@
+"""Helpers to send a test mailing using :class:`EmailSender`."""
+
 from apps.mailings.services.base.email_sender import EmailSender
+
+
+def send_test_email(email, release_type, server_version='', ipad_version='', android_version='', language='ru'):
+    """Send a single test email."""
+    sender = EmailSender(
+        emails=[email],
+        mailing_type="standard_mailing",
+        release_type=release_type,
+        server_version=server_version,
+        ipad_version=ipad_version,
+        android_version=android_version,
+        language=language,
+    )
+    return sender.send_email()

--- a/backend/apps/mailings/services/utils/attachments.py
+++ b/backend/apps/mailings/services/utils/attachments.py
@@ -1,1 +1,35 @@
 import os
+from email.mime.base import MIMEBase
+from email.mime.image import MIMEImage
+from email import encoders
+
+"""Utility stubs for mailing attachments.
+These functions are simplified versions of the original utilities
+used in the proprietary project. They perform no-op operations so that
+mail sending logic can work in this open source example."""
+
+def attach_images(msg, logger=None):
+    """Attach images to the message if any exist.
+    In this stripped down version the function does nothing."""
+    if logger:
+        logger.debug("attach_images called but no images are configured")
+
+
+def attach_files(msg, language, logger=None):
+    """Attach additional files to the message.
+    This is a stub implementation that simply logs the action."""
+    if logger:
+        logger.debug("attach_files called for language %s", language)
+
+
+def update_documentation(language, release_type, server_version, ipad_version, android_version, config):
+    """Prepare documentation before sending emails.
+    No-op for the simplified open source version."""
+    pass
+
+
+def embed_hidden_logo(html, language):
+    """Return HTML with an embedded logo.
+    The real implementation embeds an inline image. Here we just return the HTML
+    unchanged so that templates can be rendered without additional assets."""
+    return html

--- a/backend/apps/mailings/services/utils/retry_and_logging.py
+++ b/backend/apps/mailings/services/utils/retry_and_logging.py
@@ -1,1 +1,26 @@
-import os
+import logging
+from functools import wraps
+
+"""Utility decorator used in the mailing service.
+In the original project it performed automatic retries and logging.
+This simplified version only logs exceptions and re-raises them."""
+
+def log_errors(logger=None, extra_info=None):
+    """Decorator for logging exceptions inside mailing helpers."""
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except Exception as exc:  # pragma: no cover - simple logging wrapper
+                log = logger or logging.getLogger(func.__module__)
+                message = str(exc)
+                if callable(extra_info):
+                    try:
+                        message = extra_info(*args, **kwargs, error=exc)
+                    except Exception:  # safety
+                        pass
+                log.error(message)
+                raise
+        return wrapper
+    return decorator


### PR DESCRIPTION
## Summary
- add stub utilities for mailing attachments
- implement logging helper for mailing services
- allow EmailSender to run without external config
- provide helper runners for sending mail
- integrate EmailSender into the mailing task
- remove obsolete custom loggers from mailing services

## Testing
- `pip install -q -r backend/requirements.txt`
- `python backend/manage.py test apps.mailings.tests.BasicTestCase -v 2` *(fails: CSRF_TRUSTED_ORIGINS not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845136c359c8332abeb07b4d5cf7c63