### PR TITLE
Fix config file path

### DIFF
--- a/backend/apps/mailings/services/base/email_sender.py
+++ b/backend/apps/mailings/services/base/email_sender.py
@@ -23,6 +23,7 @@ from apps.mailings.services.integrations.confluence import (
     get_ipad_release_notes,
     get_android_release_notes,
 )
+from apps.mailings.services.utils.config import get_config_path
 
 # logging
 import logging
@@ -68,7 +69,7 @@ class EmailSender:
         In the open-source version the configuration file is optional. When it
         is missing we return an empty dictionary so that the sender can be
         configured programmatically."""
-        config_path = os.path.join(settings.BASE_DIR, "Main.config")
+        config_path = get_config_path()
         if not os.path.exists(config_path):
             return {}
         with open(config_path, 'r', encoding='utf-8-sig') as json_file:

--- a/backend/apps/mailings/services/integrations/confluence.py
+++ b/backend/apps/mailings/services/integrations/confluence.py
@@ -3,6 +3,7 @@ from bs4 import BeautifulSoup
 import json
 import os
 import logging
+from apps.mailings.services.utils.config import get_config_path
 
 logger = logging.getLogger(__name__)
 
@@ -12,7 +13,7 @@ logging.getLogger("rest_client").setLevel(logging.WARNING)
 
 def get_server_release_notes(server_version, lang_key):
     server_updates = None
-    with open("Main.config", 'r', encoding='utf-8-sig') as file:
+    with open(get_config_path(), 'r', encoding='utf-8-sig') as file:
         data = json.load(file)
     USERNAME = data["FILE_SHARE"]["USERNAME"]
     PASSWORD = data["FILE_SHARE"]["PASSWORD"]
@@ -38,7 +39,7 @@ def get_ipad_release_notes(ipad_version, lang_key):
     if not ipad_version:
         logger.info("Мобильная версия iPad не указана.")
         return []
-    with open("Main.config", 'r', encoding='utf-8-sig') as file:
+    with open(get_config_path(), 'r', encoding='utf-8-sig') as file:
         data = json.load(file)
     USERNAME = data["FILE_SHARE"]["USERNAME"]
     PASSWORD = data["FILE_SHARE"]["PASSWORD"]
@@ -65,7 +66,7 @@ def get_android_release_notes(android_version, lang_key):
     if not android_version:
         logger.info("Мобильная версия Android не указана.")
         return []
-    with open("Main.config", 'r', encoding='utf-8-sig') as file:
+    with open(get_config_path(), 'r', encoding='utf-8-sig') as file:
         data = json.load(file)
     USERNAME = data["FILE_SHARE"]["USERNAME"]
     PASSWORD = data["FILE_SHARE"]["PASSWORD"]

--- a/backend/apps/mailings/services/integrations/skin_move.py
+++ b/backend/apps/mailings/services/integrations/skin_move.py
@@ -10,11 +10,12 @@ from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_excep
 from apps.clients.models import Client, TechnicalInfo
 from .nextcloud import NextcloudManager
 from .yandex_disk import upload_to_nextcloud
+from apps.mailings.services.utils.config import get_config_path
 import logging
 
 logger = logging.getLogger(__name__)
 
-CONFIG_FILE = "Main.config"
+CONFIG_FILE = get_config_path()
 with open(CONFIG_FILE, 'r', encoding='utf-8-sig') as file:
     data = json.load(file)
 

--- a/backend/apps/mailings/services/utils/config.py
+++ b/backend/apps/mailings/services/utils/config.py
@@ -1,0 +1,24 @@
+import os
+from django.conf import settings
+
+
+def get_config_path(filename="Main.config"):
+    """Return absolute path to the configuration file.
+
+    The function looks for the file in the project root (one level above
+    ``settings.BASE_DIR``) and inside ``settings.BASE_DIR``.
+    ``settings.BASE_DIR`` points to ``backend/`` in this repository, but the
+    configuration file might be placed in the repository root. If the file
+    does not exist in either location, the path in the project root is
+    returned so that callers can handle ``FileNotFoundError`` themselves."""
+    # Potential locations
+    project_root = os.path.abspath(os.path.join(settings.BASE_DIR, os.pardir))
+    possible_paths = [
+        os.path.join(project_root, filename),
+        os.path.join(settings.BASE_DIR, filename),
+    ]
+    for path in possible_paths:
+        if os.path.exists(path):
+            return path
+    # Default: first path (project root)
+    return possible_paths[0]


### PR DESCRIPTION
## Summary
- centralize path resolution for `Main.config`
- use helper in `skin_move`, `confluence`, and email sender

## Testing
- `pytest -q`
- `python backend/manage.py check` *(fails: CSRF_TRUSTED_ORIGINS not found)*

------
https://chatgpt.com/codex/tasks/task_e_68451e6cd2988332ae8551c3c66d16ed