### PR TITLE
Move mailing integrations config to DB

### DIFF
--- a/.github/workflows/crag.yml
+++ b/.github/workflows/crag.yml
@@ -16,9 +16,9 @@ jobs:
         python-version: ["3.12.8"]
 
     env:
-      POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
-      POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
-      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+      DB_NAME: ${{ secrets.DB_NAME }}
+      DB_USER: ${{ secrets.DB_USER }}
+      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
       SECRET_KEY: ${{ secrets.SECRET_KEY }}
       CSRF_TRUSTED_ORIGINS: http://localhost
       DB_HOST: 127.0.0.1

--- a/.github/workflows/crag.yml
+++ b/.github/workflows/crag.yml
@@ -21,7 +21,7 @@ jobs:
       DB_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
       SECRET_KEY: ${{ secrets.SECRET_KEY }}
       CSRF_TRUSTED_ORIGINS: http://localhost
-      DB_HOST: db
+      DB_HOST: localhost
       DB_PORT: 5432
       CELERY_BROKER_URL: ${{ secrets.CELERY_BROKER_URL }}
       CELERY_RESULT_BACKEND: ${{ secrets.CELERY_RESULT_BACKEND }}
@@ -63,18 +63,6 @@ jobs:
         run: |
           mkdir -p logs
           touch logs/debug.log logs/info.log logs/warning.log logs/error.log logs/critical.log logs/celery_info.log logs/celery_error.log logs/scripts_errors.log
-
-      - name: Install PostgreSQL client
-        run: sudo apt-get install -y postgresql-client
-
-      - name: Wait for PostgreSQL
-        run: |
-          echo "Waiting for PostgreSQL to become available..."
-          for i in {1..10}; do
-            pg_isready -h db -p 5432 -U $DB_USER && break
-            echo "PostgreSQL is not ready yet. Retrying in 3s..."
-            sleep 3
-          done
 
       - name: Apply Database Migrations
         run: |

--- a/.github/workflows/crag.yml
+++ b/.github/workflows/crag.yml
@@ -21,7 +21,7 @@ jobs:
       DB_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
       SECRET_KEY: ${{ secrets.SECRET_KEY }}
       CSRF_TRUSTED_ORIGINS: http://localhost
-      DB_HOST: 127.0.0.1
+      DB_HOST: db
       DB_PORT: 5432
       CELERY_BROKER_URL: ${{ secrets.CELERY_BROKER_URL }}
       CELERY_RESULT_BACKEND: ${{ secrets.CELERY_RESULT_BACKEND }}

--- a/.github/workflows/crag.yml
+++ b/.github/workflows/crag.yml
@@ -21,7 +21,7 @@ jobs:
       DB_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
       SECRET_KEY: ${{ secrets.SECRET_KEY }}
       CSRF_TRUSTED_ORIGINS: http://localhost
-      DB_HOST: db
+      DB_HOST: localhost
       DB_PORT: 5432
       CELERY_BROKER_URL: ${{ secrets.CELERY_BROKER_URL }}
       CELERY_RESULT_BACKEND: ${{ secrets.CELERY_RESULT_BACKEND }}

--- a/.github/workflows/crag.yml
+++ b/.github/workflows/crag.yml
@@ -21,7 +21,7 @@ jobs:
       DB_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
       SECRET_KEY: ${{ secrets.SECRET_KEY }}
       CSRF_TRUSTED_ORIGINS: http://localhost
-      DB_HOST: localhost
+      DB_HOST: db
       DB_PORT: 5432
       CELERY_BROKER_URL: ${{ secrets.CELERY_BROKER_URL }}
       CELERY_RESULT_BACKEND: ${{ secrets.CELERY_RESULT_BACKEND }}
@@ -63,6 +63,18 @@ jobs:
         run: |
           mkdir -p logs
           touch logs/debug.log logs/info.log logs/warning.log logs/error.log logs/critical.log logs/celery_info.log logs/celery_error.log logs/scripts_errors.log
+
+      - name: Install PostgreSQL client
+        run: sudo apt-get install -y postgresql-client
+
+      - name: Wait for PostgreSQL
+        run: |
+          echo "Waiting for PostgreSQL to become available..."
+          for i in {1..10}; do
+            pg_isready -h db -p 5432 -U $DB_USER && break
+            echo "PostgreSQL is not ready yet. Retrying in 3s..."
+            sleep 3
+          done
 
       - name: Apply Database Migrations
         run: |

--- a/.github/workflows/crag.yml
+++ b/.github/workflows/crag.yml
@@ -16,9 +16,9 @@ jobs:
         python-version: ["3.12.8"]
 
     env:
-      DB_NAME: ${{ secrets.DB_NAME }}
-      DB_USER: ${{ secrets.DB_USER }}
-      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+      DB_NAME: ${{ secrets.POSTGRES_DB }}
+      DB_USER: ${{ secrets.POSTGRES_USER }}
+      DB_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
       SECRET_KEY: ${{ secrets.SECRET_KEY }}
       CSRF_TRUSTED_ORIGINS: http://localhost
       DB_HOST: 127.0.0.1
@@ -35,9 +35,9 @@ jobs:
       db:
         image: postgres:13
         env:
-          POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
-          POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
-          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          DB_NAME: ${{ secrets.POSTGRES_DB }}
+          DB_USER: ${{ secrets.POSTGRES_USER }}
+          DB_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
         ports:
           - 5432:5432
 

--- a/backend/apps/configurations/admin.py
+++ b/backend/apps/configurations/admin.py
@@ -1,9 +1,11 @@
 from django.contrib import admin
-from .models import OIDCSettings, SMTPSettings
+from .models import OIDCSettings, SMTPSettings, IntegrationSettings
+
 
 @admin.register(OIDCSettings)
 class OIDCSettingsAdmin(admin.ModelAdmin):
     list_display = ("keycloak_base_url", "realm", "client_id")
+
 
 @admin.register(SMTPSettings)
 class SMTPSettingsAdmin(admin.ModelAdmin):
@@ -15,3 +17,8 @@ class SMTPSettingsAdmin(admin.ModelAdmin):
         if obj.enabled:
             SMTPSettings.objects.exclude(id=obj.id).update(enabled=False)
         super().save_model(request, obj, form, change)
+
+
+@admin.register(IntegrationSettings)
+class IntegrationSettingsAdmin(admin.ModelAdmin):
+    list_display = ("id",)

--- a/backend/apps/configurations/config_loader.py
+++ b/backend/apps/configurations/config_loader.py
@@ -49,3 +49,34 @@ def get_smtp_settings():
     except Exception as e:
         logger.error(f"❌ Ошибка загрузки SMTP настроек: {e}")
         return None
+
+
+def get_integration_settings():
+    """Получает настройки интеграций из базы"""
+    try:
+        IntegrationSettings = apps.get_model("configurations", "IntegrationSettings")
+        settings_obj = IntegrationSettings.objects.first()
+        if not settings_obj:
+            return {}
+        return {
+            "YANDEX_DISK": {
+                "OAUTH-TOKEN": settings_obj.yandex_token,
+                "CLIENT_ID": settings_obj.yandex_client_id,
+                "CLIENT_SECRET": settings_obj.yandex_client_secret,
+            },
+            "YANDEX_DISK_FOLDERS": settings_obj.yandex_disk_folders,
+            "FILE_SHARE": {
+                "USERNAME": settings_obj.file_share_username,
+                "PASSWORD": settings_obj.file_share_password,
+                "DOMAIN": settings_obj.file_share_domain,
+                "SMB_SERVER": settings_obj.file_share_server,
+            },
+            "NEXT_CLOUD": {
+                "URL": settings_obj.nextcloud_url,
+                "USER": settings_obj.nextcloud_user,
+                "PASSWORD": settings_obj.nextcloud_password,
+            },
+        }
+    except Exception as e:
+        logger.error(f"❌ Ошибка загрузки интеграционных настроек: {e}")
+        return {}

--- a/backend/apps/configurations/models.py
+++ b/backend/apps/configurations/models.py
@@ -1,9 +1,10 @@
 from django.db import models
 
+
 class OIDCSettings(models.Model):
     """Настройки OpenID Connect (OIDC) для Keycloak."""
-    
-    enabled = models.BooleanField("Включено", default=False)  # Флаг включения
+
+    enabled = models.BooleanField("Включено", default=False)
     keycloak_base_url = models.URLField("Keycloak URL", default="https://keycloak.example.com/auth/")
     realm = models.CharField("Realm", max_length=100, default="realm")
     client_id = models.CharField("Client ID", max_length=255, default="client-id")
@@ -20,7 +21,7 @@ class OIDCSettings(models.Model):
 class SMTPSettings(models.Model):
     """Настройки SMTP для отправки почты"""
 
-    enabled = models.BooleanField("Включено", default=False)  # Флаг включения
+    enabled = models.BooleanField("Включено", default=False)
     smtp_host = models.CharField("SMTP сервер", max_length=255, default="smtp.example.com")
     smtp_port = models.IntegerField("SMTP порт", default=587)
     smtp_user = models.CharField("SMTP пользователь", max_length=255, blank=True, null=True)
@@ -34,3 +35,32 @@ class SMTPSettings(models.Model):
     class Meta:
         verbose_name = "SMTP Настройки"
         verbose_name_plural = "SMTP Настройки"
+
+
+class IntegrationSettings(models.Model):
+    """Настройки интеграций (Яндекс.Диск, Nextcloud и т.д.)"""
+
+    # Yandex Disk
+    yandex_token = models.CharField("OAuth-токен", max_length=255, blank=True)
+    yandex_client_id = models.CharField("Yandex Client ID", max_length=255, blank=True)
+    yandex_client_secret = models.CharField("Yandex Client Secret", max_length=255, blank=True)
+    yandex_disk_folders = models.JSONField("Пути Яндекс.Диска", default=dict, blank=True)
+
+    # Nextcloud
+    nextcloud_url = models.URLField("Nextcloud URL", blank=True)
+    nextcloud_user = models.CharField("Nextcloud пользователь", max_length=255, blank=True)
+    nextcloud_password = models.CharField("Nextcloud пароль", max_length=255, blank=True)
+
+    # SMB/File share
+    file_share_username = models.CharField("SMB пользователь", max_length=255, blank=True)
+    file_share_password = models.CharField("SMB пароль", max_length=255, blank=True)
+    file_share_domain = models.CharField("SMB домен", max_length=255, blank=True)
+    file_share_server = models.CharField("SMB сервер", max_length=255, blank=True)
+
+    def __str__(self):
+        return "Integration settings"
+
+    class Meta:
+        verbose_name = "Интеграционные настройки"
+        verbose_name_plural = "Интеграционные настройки"
+

--- a/backend/apps/mailings/services/base/email_sender.py
+++ b/backend/apps/mailings/services/base/email_sender.py
@@ -24,6 +24,7 @@ from apps.mailings.services.integrations.confluence import (
     get_android_release_notes,
 )
 from apps.mailings.services.utils.config import get_config_path
+from apps.configurations.config_loader import get_integration_settings
 
 # logging
 import logging
@@ -69,6 +70,9 @@ class EmailSender:
         In the open-source version the configuration file is optional. When it
         is missing we return an empty dictionary so that the sender can be
         configured programmatically."""
+        settings_data = get_integration_settings()
+        if settings_data:
+            return settings_data
         config_path = get_config_path()
         if not os.path.exists(config_path):
             return {}

--- a/backend/apps/mailings/services/integrations/confluence.py
+++ b/backend/apps/mailings/services/integrations/confluence.py
@@ -4,6 +4,7 @@ import json
 import os
 import logging
 from apps.mailings.services.utils.config import get_config_path
+from apps.configurations.config_loader import get_integration_settings
 
 logger = logging.getLogger(__name__)
 
@@ -13,10 +14,9 @@ logging.getLogger("rest_client").setLevel(logging.WARNING)
 
 def get_server_release_notes(server_version, lang_key):
     server_updates = None
-    with open(get_config_path(), 'r', encoding='utf-8-sig') as file:
-        data = json.load(file)
-    USERNAME = data["FILE_SHARE"]["USERNAME"]
-    PASSWORD = data["FILE_SHARE"]["PASSWORD"]
+    data = get_integration_settings()
+    USERNAME = data.get("FILE_SHARE", {}).get("USERNAME")
+    PASSWORD = data.get("FILE_SHARE", {}).get("PASSWORD")
     url = 'https://confluence.boardmaps.ru'
     try:
         confluence = Confluence(url=url, username=USERNAME, password=PASSWORD)
@@ -39,10 +39,9 @@ def get_ipad_release_notes(ipad_version, lang_key):
     if not ipad_version:
         logger.info("Мобильная версия iPad не указана.")
         return []
-    with open(get_config_path(), 'r', encoding='utf-8-sig') as file:
-        data = json.load(file)
-    USERNAME = data["FILE_SHARE"]["USERNAME"]
-    PASSWORD = data["FILE_SHARE"]["PASSWORD"]
+    data = get_integration_settings()
+    USERNAME = data.get("FILE_SHARE", {}).get("USERNAME")
+    PASSWORD = data.get("FILE_SHARE", {}).get("PASSWORD")
     url = 'https://confluence.boardmaps.ru'
     try:
         confluence = Confluence(url=url, username=USERNAME, password=PASSWORD)
@@ -66,10 +65,9 @@ def get_android_release_notes(android_version, lang_key):
     if not android_version:
         logger.info("Мобильная версия Android не указана.")
         return []
-    with open(get_config_path(), 'r', encoding='utf-8-sig') as file:
-        data = json.load(file)
-    USERNAME = data["FILE_SHARE"]["USERNAME"]
-    PASSWORD = data["FILE_SHARE"]["PASSWORD"]
+    data = get_integration_settings()
+    USERNAME = data.get("FILE_SHARE", {}).get("USERNAME")
+    PASSWORD = data.get("FILE_SHARE", {}).get("PASSWORD")
     url = 'https://confluence.boardmaps.ru'
     try:
         confluence = Confluence(url=url, username=USERNAME, password=PASSWORD)

--- a/backend/apps/mailings/services/integrations/skin_move.py
+++ b/backend/apps/mailings/services/integrations/skin_move.py
@@ -1,5 +1,4 @@
 import os
-import json
 import subprocess
 import tempfile
 import shutil
@@ -7,27 +6,24 @@ import shlex
 from urllib.parse import quote
 from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
 
-from apps.clients.models import Client, TechnicalInfo
+from apps.clients.models import Client
 from apps.mailings.services.integrations.nextcloud import NextcloudManager
 from apps.mailings.services.integrations.yandex_disk import upload_to_nextcloud
-from apps.mailings.services.utils.config import get_config_path
+from apps.configurations.config_loader import get_integration_settings
 import logging
 
 logger = logging.getLogger(__name__)
 
-CONFIG_FILE = get_config_path()
-with open(CONFIG_FILE, 'r', encoding='utf-8-sig') as file:
-    data = json.load(file)
+data = get_integration_settings()
+USERNAME = data.get("FILE_SHARE", {}).get("USERNAME")
+PASSWORD = data.get("FILE_SHARE", {}).get("PASSWORD")
+DOMAIN = data.get("FILE_SHARE", {}).get("DOMAIN")
+SMB_SERVER = data.get("FILE_SHARE", {}).get("SMB_SERVER")
+SHARE_PATH = f"//{SMB_SERVER}.{DOMAIN}/data/" if SMB_SERVER and DOMAIN else ""
 
-USERNAME = data["FILE_SHARE"]["USERNAME"]
-PASSWORD = data["FILE_SHARE"]["PASSWORD"]
-DOMAIN = data["FILE_SHARE"]["DOMAIN"]
-SMB_SERVER = data["FILE_SHARE"]["SMB_SERVER"]
-SHARE_PATH = f"//{SMB_SERVER}.{DOMAIN}/data/"
-
-NEXTCLOUD_URL = data["NEXT_CLOUD"]["URL"]
-NEXTCLOUD_USERNAME = data["NEXT_CLOUD"]["USER"]
-NEXTCLOUD_PASSWORD = data["NEXT_CLOUD"]["PASSWORD"]
+NEXTCLOUD_URL = data.get("NEXT_CLOUD", {}).get("URL")
+NEXTCLOUD_USERNAME = data.get("NEXT_CLOUD", {}).get("USER")
+NEXTCLOUD_PASSWORD = data.get("NEXT_CLOUD", {}).get("PASSWORD")
 
 nextcloud_module = NextcloudManager(NEXTCLOUD_URL, NEXTCLOUD_USERNAME, NEXTCLOUD_PASSWORD)
 

--- a/backend/apps/mailings/tasks.py
+++ b/backend/apps/mailings/tasks.py
@@ -166,10 +166,10 @@ def send_mailing_task(self, mailing_id):
                     android_version=mailing.android_version,
                     language=lang,
                 )
-                sender.config = {
+                sender.config.update({
                     "MAIL_SETTINGS": smtp_config,
                     "MAIL_SETTINGS_SUPPORT": smtp_config,
-                }
+                })
                 sender.send_email()
 
                 recipient.status = RecipientStatus.SENT


### PR DESCRIPTION
## Summary
- store Yandex Disk and other integration parameters in new `IntegrationSettings` model
- expose helper to load integration settings from DB
- use DB configuration in email sender and integrations
- keep SMTP settings when sending a mailing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684568d2e968833299d9709a299ba0d2