### PR TITLE
Extend integration settings

### DIFF
--- a/backend/apps/configurations/config_loader.py
+++ b/backend/apps/configurations/config_loader.py
@@ -64,6 +64,11 @@ def get_integration_settings():
                 "CLIENT_ID": settings_obj.yandex_client_id,
                 "CLIENT_SECRET": settings_obj.yandex_client_secret,
             },
+            "YANDEX_DBS_TEAM": {
+                "OAUTH-TOKEN": settings_obj.yandex_dbs_token,
+                "CLIENT_ID": settings_obj.yandex_dbs_client_id,
+                "CLIENT_SECRET": settings_obj.yandex_dbs_client_secret,
+            },
             "YANDEX_DISK_FOLDERS": settings_obj.yandex_disk_folders,
             "FILE_SHARE": {
                 "USERNAME": settings_obj.file_share_username,
@@ -71,10 +76,32 @@ def get_integration_settings():
                 "DOMAIN": settings_obj.file_share_domain,
                 "SMB_SERVER": settings_obj.file_share_server,
             },
+            "CONFLUENCE": {
+                "USERNAME": settings_obj.confluence_username,
+                "PASSWORD": settings_obj.confluence_password,
+            },
             "NEXT_CLOUD": {
                 "URL": settings_obj.nextcloud_url,
                 "USER": settings_obj.nextcloud_user,
                 "PASSWORD": settings_obj.nextcloud_password,
+            },
+            "TELEGRAM_SETTINGS": {
+                "PROXY": settings_obj.telegram_proxy,
+                "BOT_ID": settings_obj.telegram_bot_id,
+                "BOT_TOKEN": settings_obj.telegram_bot_token,
+            },
+            "TFS": {
+                "assigned_to_product": settings_obj.tfs_assigned_to_product,
+            },
+            "TICKET_SETTINGS": {
+                "API_ENDPOINT": settings_obj.ticket_api_endpoint,
+                "API_KEY": settings_obj.ticket_api_key,
+                "API_SECRET": settings_obj.ticket_api_secret,
+            },
+            "SEND_ALERT": {
+                "GROUP_SUPPOR_TEAM": settings_obj.alert_group_support_team,
+                "GROUP_RELEASE": settings_obj.alert_group_release,
+                "GROUP_TICKETS": settings_obj.alert_group_tickets,
             },
         }
     except Exception as e:

--- a/backend/apps/configurations/models.py
+++ b/backend/apps/configurations/models.py
@@ -57,6 +57,33 @@ class IntegrationSettings(models.Model):
     file_share_domain = models.CharField("SMB домен", max_length=255, blank=True)
     file_share_server = models.CharField("SMB сервер", max_length=255, blank=True)
 
+    # Confluence credentials
+    confluence_username = models.CharField("Confluence пользователь", max_length=255, blank=True)
+    confluence_password = models.CharField("Confluence пароль", max_length=255, blank=True)
+
+    # Telegram settings
+    telegram_proxy = models.CharField("Telegram прокси", max_length=255, blank=True)
+    telegram_bot_id = models.CharField("Telegram Bot ID", max_length=255, blank=True)
+    telegram_bot_token = models.CharField("Telegram Bot Token", max_length=255, blank=True)
+
+    # TFS settings
+    tfs_assigned_to_product = models.CharField("TFS Assigned To", max_length=255, blank=True)
+
+    # Ticket system settings
+    ticket_api_endpoint = models.URLField("Ticket API Endpoint", blank=True)
+    ticket_api_key = models.CharField("Ticket API Key", max_length=255, blank=True)
+    ticket_api_secret = models.CharField("Ticket API Secret", max_length=255, blank=True)
+
+    # Alert groups
+    alert_group_support_team = models.CharField("Группа поддержки", max_length=255, blank=True)
+    alert_group_release = models.CharField("Группа релизов", max_length=255, blank=True)
+    alert_group_tickets = models.CharField("Группа тикетов", max_length=255, blank=True)
+
+    # Yandex Disk for BMs Team
+    yandex_dbs_token = models.CharField("Yandex DBS OAuth-токен", max_length=255, blank=True)
+    yandex_dbs_client_id = models.CharField("Yandex DBS Client ID", max_length=255, blank=True)
+    yandex_dbs_client_secret = models.CharField("Yandex DBS Client Secret", max_length=255, blank=True)
+
     def __str__(self):
         return "Integration settings"
 

--- a/backend/apps/mailings/services/integrations/confluence.py
+++ b/backend/apps/mailings/services/integrations/confluence.py
@@ -15,8 +15,8 @@ logging.getLogger("rest_client").setLevel(logging.WARNING)
 def get_server_release_notes(server_version, lang_key):
     server_updates = None
     data = get_integration_settings()
-    USERNAME = data.get("FILE_SHARE", {}).get("USERNAME")
-    PASSWORD = data.get("FILE_SHARE", {}).get("PASSWORD")
+    USERNAME = data.get("CONFLUENCE", {}).get("USERNAME")
+    PASSWORD = data.get("CONFLUENCE", {}).get("PASSWORD")
     url = 'https://confluence.boardmaps.ru'
     try:
         confluence = Confluence(url=url, username=USERNAME, password=PASSWORD)
@@ -40,8 +40,8 @@ def get_ipad_release_notes(ipad_version, lang_key):
         logger.info("Мобильная версия iPad не указана.")
         return []
     data = get_integration_settings()
-    USERNAME = data.get("FILE_SHARE", {}).get("USERNAME")
-    PASSWORD = data.get("FILE_SHARE", {}).get("PASSWORD")
+    USERNAME = data.get("CONFLUENCE", {}).get("USERNAME")
+    PASSWORD = data.get("CONFLUENCE", {}).get("PASSWORD")
     url = 'https://confluence.boardmaps.ru'
     try:
         confluence = Confluence(url=url, username=USERNAME, password=PASSWORD)
@@ -66,8 +66,8 @@ def get_android_release_notes(android_version, lang_key):
         logger.info("Мобильная версия Android не указана.")
         return []
     data = get_integration_settings()
-    USERNAME = data.get("FILE_SHARE", {}).get("USERNAME")
-    PASSWORD = data.get("FILE_SHARE", {}).get("PASSWORD")
+    USERNAME = data.get("CONFLUENCE", {}).get("USERNAME")
+    PASSWORD = data.get("CONFLUENCE", {}).get("PASSWORD")
     url = 'https://confluence.boardmaps.ru'
     try:
         confluence = Confluence(url=url, username=USERNAME, password=PASSWORD)

--- a/example_Main.config
+++ b/example_Main.config
@@ -53,6 +53,11 @@
         "DOMAIN" : "corp.example.com",
         "SMB_SERVER" : "DOMAIN"
     },
+    "CONFLUENCE":
+    {
+        "USERNAME" : "",
+        "PASSWORD" : ""
+    },
     "NEXT_CLOUD":
     {
         "URL" : "https://cloud.example.ru",


### PR DESCRIPTION
## Summary
- support additional integration settings used by mailing
- allow separate Confluence credentials
- update example config

## Testing
- `python backend/manage.py test` *(fails: CSRF_TRUSTED_ORIGINS not found)*

------
https://chatgpt.com/codex/tasks/task_e_68457fde43b88332991e68d4417091e5