### PR TITLE
Fix mailing logs not appearing via WebSocket

### DIFF
--- a/backend/apps/mailings/views.py
+++ b/backend/apps/mailings/views.py
@@ -3,11 +3,12 @@ from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from django.contrib import messages
+from django.utils import timezone
 from collections import defaultdict
 from .models import Mailing, MailingLog, MailingRecipient, MailingTestRecipient, Component, MailingStatus, MailingMode
 from apps.clients.models import Client
 from .constants import TEST_RECIPIENT_LABEL
-from .tasks import send_mailing_task
+from .tasks import send_mailing_task, send_ws_event, log_event
 from .forms import MailingForm
 
 

--- a/backend/config/asgi.py
+++ b/backend/config/asgi.py
@@ -8,6 +8,7 @@ https://docs.djangoproject.com/en/5.1/howto/deployment/asgi/
 """
 
 import os
+from channels.routing import ProtocolTypeRouter, URLRouter
 
 # Django settings must be configured before importing application modules that
 # rely on them (e.g. models). Set the environment variable first and load
@@ -23,7 +24,10 @@ from channels.routing import ProtocolTypeRouter, URLRouter
 from channels.auth import AuthMiddlewareStack
 from apps.websocket.routing import websocket_urlpatterns
 
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
 application = ProtocolTypeRouter({
+    "http": get_asgi_application(),
     "http": django_asgi_app,
     "websocket": AuthMiddlewareStack(
         URLRouter(websocket_urlpatterns)

--- a/backend/config/asgi.py
+++ b/backend/config/asgi.py
@@ -10,16 +10,21 @@ https://docs.djangoproject.com/en/5.1/howto/deployment/asgi/
 import os
 
 # Django settings must be configured before importing application modules that
-# rely on them (e.g. models). Set the environment variable first.
+# rely on them (e.g. models). Set the environment variable first and load
+# Django so model imports succeed.
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 
-from channels.routing import ProtocolTypeRouter, URLRouter
 from django.core.asgi import get_asgi_application
+
+# Calling get_asgi_application() initializes Django and ensures apps are loaded
+django_asgi_app = get_asgi_application()
+
+from channels.routing import ProtocolTypeRouter, URLRouter
 from channels.auth import AuthMiddlewareStack
 from apps.websocket.routing import websocket_urlpatterns
 
 application = ProtocolTypeRouter({
-    "http": get_asgi_application(),
+    "http": django_asgi_app,
     "websocket": AuthMiddlewareStack(
         URLRouter(websocket_urlpatterns)
     ),

--- a/backend/config/asgi.py
+++ b/backend/config/asgi.py
@@ -8,12 +8,15 @@ https://docs.djangoproject.com/en/5.1/howto/deployment/asgi/
 """
 
 import os
+
+# Django settings must be configured before importing application modules that
+# rely on them (e.g. models). Set the environment variable first.
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
 from channels.routing import ProtocolTypeRouter, URLRouter
 from django.core.asgi import get_asgi_application
 from channels.auth import AuthMiddlewareStack
 from apps.websocket.routing import websocket_urlpatterns
-
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 
 application = ProtocolTypeRouter({
     "http": get_asgi_application(),


### PR DESCRIPTION
## Summary
- emit all mailing logs via WebSocket
- avoid duplicated log messages when using `log_event`

## Testing
- `pip install -r requirements.txt` *(fails: couldn't run due to environment limitations)*
- `python manage.py test` *(fails: missing environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_684581e532e88332bee1e9c726872c9a