### PR TITLE
Add unified mailing logger

### DIFF
--- a/backend/apps/mailings/logging_utils.py
+++ b/backend/apps/mailings/logging_utils.py
@@ -1,0 +1,76 @@
+import logging
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
+from django.utils import timezone
+from .models import Mailing, MailingLog, LogLevel
+
+
+class MailLogHandler(logging.Handler):
+    """Logging handler that writes mailing logs to DB and WebSocket."""
+    def __init__(self, mailing_id):
+        super().__init__()
+        self.mailing_id = mailing_id
+
+    def emit(self, record):
+        message = self.format(record)
+        level_map = {
+            logging.INFO: LogLevel.INFO,
+            logging.WARNING: LogLevel.WARNING,
+            logging.ERROR: LogLevel.ERROR,
+            logging.CRITICAL: LogLevel.CRITICAL,
+        }
+        level = level_map.get(record.levelno, LogLevel.INFO)
+
+        mailing = Mailing.objects.get(id=self.mailing_id)
+        MailingLog.objects.create(mailing=mailing, level=level, message=message)
+
+        channel_layer = get_channel_layer()
+        async_to_sync(channel_layer.group_send)(
+            f"mailing_{self.mailing_id}",
+            {
+                "type": "mailing_update",
+                "log": {
+                    "level": level,
+                    "message": message,
+                    "timestamp": timezone.now().isoformat(),
+                },
+            },
+        )
+
+
+def send_ws_event(mailing_id, event_type, message):
+    """Send an event to the WebSocket group for a mailing."""
+    channel_layer = get_channel_layer()
+    async_to_sync(channel_layer.group_send)(
+        f"mailing_{mailing_id}",
+        {
+            "type": "mailing_update",
+            event_type: message,
+        },
+    )
+
+
+def log_event(mailing_id, level, message):
+    """Log a message using the MailLogHandler interface."""
+    logger = get_mailing_logger(mailing_id)
+    log_methods = {
+        LogLevel.INFO: logger.info,
+        LogLevel.WARNING: logger.warning,
+        LogLevel.ERROR: logger.error,
+        LogLevel.CRITICAL: logger.critical,
+    }
+    log_method = log_methods.get(level, logger.info)
+    log_method(message)
+
+
+def get_mailing_logger(mailing_id, name=None):
+    """Return a logger configured with a MailLogHandler."""
+    logger_name = name or f"mailing_{mailing_id}"
+    logger = logging.getLogger(logger_name)
+    if not any(
+        isinstance(h, MailLogHandler) and h.mailing_id == mailing_id
+        for h in logger.handlers
+    ):
+        logger.addHandler(MailLogHandler(mailing_id))
+    logger.setLevel(logging.INFO)
+    return logger

--- a/backend/apps/mailings/services/utils/retry_and_logging.py
+++ b/backend/apps/mailings/services/utils/retry_and_logging.py
@@ -13,7 +13,16 @@ def log_errors(logger=None, extra_info=None):
             try:
                 return func(*args, **kwargs)
             except Exception as exc:  # pragma: no cover - simple logging wrapper
-                log = logger or logging.getLogger(func.__module__)
+                if logger:
+                    log = logger
+                else:
+                    obj = args[0] if args else None
+                    if obj and hasattr(obj, "error_logger"):
+                        log = obj.error_logger
+                    elif obj and hasattr(obj, "logger"):
+                        log = obj.logger
+                    else:
+                        log = logging.getLogger(func.__module__)
                 message = str(exc)
                 if callable(extra_info):
                     try:

--- a/backend/apps/mailings/views.py
+++ b/backend/apps/mailings/views.py
@@ -8,7 +8,8 @@ from collections import defaultdict
 from .models import Mailing, MailingLog, MailingRecipient, MailingTestRecipient, Component, MailingStatus, MailingMode
 from apps.clients.models import Client
 from .constants import TEST_RECIPIENT_LABEL
-from .tasks import send_mailing_task, send_ws_event, log_event
+from .tasks import send_mailing_task
+from .logging_utils import send_ws_event, log_event
 from .forms import MailingForm
 
 


### PR DESCRIPTION
## Summary
- add shared logging utility for mailings
- use unified logger in mailing tasks and views
- forward object loggers through retry decorator

## Testing
- `pip install -r backend/requirements.txt`
- `python manage.py test` *(fails: CSRF_TRUSTED_ORIGINS not set)*

------
https://chatgpt.com/codex/tasks/task_e_684597d7127c8332a0b9eebfa5a1a0e1