### PR TITLE
Handle prod mode input for mailings

### DIFF
--- a/backend/apps/mailings/forms.py
+++ b/backend/apps/mailings/forms.py
@@ -27,23 +27,30 @@ class MailingForm(forms.ModelForm):
         self.fields['mode'].initial = 'test'
 
     def clean_test_email(self):
-        """ Валидация: test_email обязателен в режиме 'test'. """
+        """Валидация и очистка тестового email."""
         mode = self.cleaned_data.get('mode')
         test_email = self.cleaned_data.get('test_email')
 
         if mode == MailingMode.TEST and not test_email:
             raise ValidationError("В тестовом режиме необходимо указать email.")
-        
+
+        if mode != MailingMode.TEST:
+            return None
+
         return test_email
 
     def clean_language(self):
-        """ Валидация: язык обязателен в тестовом режиме. """
+        """Валидация и очистка поля языка."""
         mode = self.cleaned_data.get('mode')
         language = self.cleaned_data.get('language')
 
         if mode == MailingMode.TEST and not language:
             raise ValidationError("В тестовом режиме необходимо указать язык ")
-        
+
+        # При продакшн-режиме язык не должен передаваться
+        if mode != MailingMode.TEST:
+            return None
+
         return language
 
     def clean(self):

--- a/backend/apps/mailings/static/mailings/js/create_mailing.js
+++ b/backend/apps/mailings/static/mailings/js/create_mailing.js
@@ -18,9 +18,19 @@ document.addEventListener("DOMContentLoaded", function () {
 
     function toggleTestModeFields() {
         let isTestMode = modeField.value === "test";
+
         testEmailWrapper.style.display = isTestMode ? "block" : "none";
         testEmailField.required = isTestMode;
+        testEmailField.disabled = !isTestMode;
+
         languageWrapper.style.display = isTestMode ? "block" : "none";
+        const languageField = document.getElementById("id_language");
+        languageField.disabled = !isTestMode;
+
+        if (!isTestMode) {
+            testEmailField.value = "";
+            languageField.value = "";
+        }
     }
 
     function toggleSaaSUpdateTime() {


### PR DESCRIPTION
## Summary
- clear mailing `language` and `test_email` values when mode is prod
- disable corresponding form fields via JS to avoid sending them to the server

## Testing
- `pip install -r requirements.txt`
- `python manage.py test` *(fails: `CSRF_TRUSTED_ORIGINS not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6845aa9851e08332b5b882d6b138c540