### PR TITLE
Allow editing repeated mailing before sending

### DIFF
--- a/backend/apps/mailings/static/mailings/js/mailing_detail.js
+++ b/backend/apps/mailings/static/mailings/js/mailing_detail.js
@@ -12,7 +12,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
     function attachRepeatHandler(btn) {
         btn.addEventListener("click", function () {
-            if (confirm("Повторить рассылку с теми же параметрами?")) {
+            if (confirm("Создать новую рассылку на основе этой?")) {
                 fetch(`/mailings/repeat/${mailingId}/`, {
                     method: "POST",
                     headers: {"X-CSRFToken": getCSRFToken()},

--- a/backend/apps/mailings/views.py
+++ b/backend/apps/mailings/views.py
@@ -114,7 +114,7 @@ def repeat_mailing(request, mailing_id):
     new_mailing = Mailing.objects.create(
         mode=mailing.mode,
         release_type=mailing.release_type,
-        status=MailingStatus.PENDING,
+        status=MailingStatus.DRAFT,
         language=mailing.language,
         server_version=mailing.server_version,
         ipad_version=mailing.ipad_version,
@@ -138,15 +138,12 @@ def repeat_mailing(request, mailing_id):
                 email=r.email
             )
 
-    # Запускаем повторно
-    new_mailing.status = MailingStatus.PENDING
     new_mailing.save()
-    send_mailing_task.delay(new_mailing.id)
 
     return JsonResponse({
-        "status": "repeated",
-        "message": f"Создана и запущена новая рассылка #{new_mailing.id}",
-        "redirect_url": f"/mailings/detail/{new_mailing.id}/"
+        "status": "created",
+        "message": f"Создан черновик новой рассылки #{new_mailing.id}",
+        "redirect_url": f"/mailings/edit/{new_mailing.id}/"
     })
 
 


### PR DESCRIPTION
## Summary
- create repeated mailings as draft instead of sending immediately
- redirect to edit page when repeating a mailing
- adjust JS confirmation message accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845efb100a48332822ea8b472332cf2